### PR TITLE
Improvements for communication with frontend

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -1,7 +1,7 @@
 import yt_dlp  # type: ignore
 from hashlib import sha256
 from concurrent import futures
-from os import makedirs
+import os
 from multiprocessing import cpu_count
 import json
 
@@ -30,7 +30,16 @@ class Download:
         self.link = link
         self.__name = sha256(link.encode()).hexdigest()
         song_dir = f"downloads/{self.__name}"
-        makedirs(song_dir, exist_ok=True)
+        
+        if os.path.isdir(song_dir):
+            def do_nothing():
+                ...
+
+            self.__downloader = self.__executor.submit(do_nothing)
+            self.__informator = self.__executor.submit(do_nothing)
+            return
+
+        os.makedirs(song_dir, exist_ok=True)
         song_file = f"{song_dir}/audio.%(ext)s"
         metadata_file = f"{song_dir}/metadata.json"
 
@@ -71,8 +80,6 @@ class Download:
         Awaits for end of downloading and returns directory name
         when it is finished
         """
-        self.__informator.result()
-        self.__downloader.result()
         if self.__name == "":
             raise Exception("Something gone wrong with your download")
         return self.__name

--- a/src/engine.py
+++ b/src/engine.py
@@ -20,6 +20,9 @@ class Task:
         """
         Processes a single song inside queue
         """
+        if os.path.exists(os.path.join(self.__path, "htdemucs/audio/vocals.mp3")):
+            return
+
         demucs.separate.main(["--mp3", "--two-stems", "vocals", "-o", self.__path, os.path.join(self.__path, "audio.mp3")])
 
     def is_done(self) -> bool:


### PR DESCRIPTION
- Make endpoint /v1/songs non-blocking
  - Return song hash immediately
  - Waiting for download to end is launched in new thread
  - Front will poll endpoint /v1/songinfo in some intervals to check if song is processed
- Add checks to `Download` and `Engine` to save data between backend restarts